### PR TITLE
Fixes #5 by adding better version comparison

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,7 +10,8 @@ end
 taglib_bin = find_executable 'taglib-config'
 taglib_version = `#{taglib_bin} --version`.chomp if taglib_bin
 
-if taglib_bin.nil? || taglib_version < '1.7.2'
+if taglib_bin.nil? ||
+   Gem::Version.new(taglib_version) < Gem::Version.new('1.7.2')
   error <<-DESC
 
 \e[31mYou must have TagLib >= 1.7.2 installed in order to use taglib-ruby.\e[0m


### PR DESCRIPTION
I believe this project is dead, but this fixes #5 

The current version of Taglib is 1.11.1

```
'1.11.1' < '1.7.2'
=> true
```

The expected result is false.

```
Gem::Version.new('1.11.1') < Gem::Version.new('1.7.2')
=> false
```

